### PR TITLE
error handling: disable fatal error

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -52,6 +52,10 @@
       "TikaAllTheFiles_PropertyMap": {
         "value": [],
         "description": "Additional or override mappings for Tika metadata properties"
+      },
+      "TikaAllTheFiles_ThrowExceptionOnTikaFailure": {
+        "value": true,
+        "description": "If connection with tike server failed - to throw error (false) or just log it"
       }
     },
     "MessagesDirs": {

--- a/src/Core.php
+++ b/src/Core.php
@@ -705,7 +705,13 @@ class Core {
       } // while ( $triesRemaining > 0 )
 
       // Retries exhausted.  Oh, well, at least we (re)tried.
-      throw new MWException( "Tika query exhausted retries for {$filePath}" );
+      if( $this->config->get( 'ThrowExceptionOnTikaFailure' ) ) {
+        throw new MWException( "Failed to communicate with Tika server" );
+      }
+      else{
+        $this->logger->warning( "Failed to communicate with Tika server" );
+        return [];
+      }
     }
     finally {
       fclose( $inputFile );


### PR DESCRIPTION
For now, if the calls to Tika fail, the whole process fails. This is not ideal, but it is better than the alternative of silently failing. We should add a configuration option to disable fatal errors, and then we can add a retry mechanism.
We let the user to decide if he wants to disable fatal errors or not,
using config TikaAllTheFiles_ThrowExceptionOnTikaFailure